### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     # Run weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'
 
+permissions:
+  contents: read
+
 env:
   DOCKER_BUILDKIT: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/cypheroxide/desktop-setup/security/code-scanning/3](https://github.com/cypheroxide/desktop-setup/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's actions, the minimal required permissions are `contents: read` to allow the workflow to read repository contents. No write permissions are necessary since the workflow does not modify repository data or interact with pull requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
