### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  statuses: read
 name: Update Status Badges
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cypheroxide/desktop-setup/security/code-scanning/2](https://github.com/cypheroxide/desktop-setup/security/code-scanning/2)

To fix the issue, we will add an explicit `permissions` block at the root level of the workflow file. This will ensure that the workflow operates with the minimal permissions required. Based on the actions performed in the workflow, the following permissions are needed:

- `contents: write` to allow the workflow to commit and push changes to the repository.
- `statuses: read` to fetch the status of the workflow runs via the GitHub API.

We will place the `permissions` block directly under the workflow `name` field to ensure it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
